### PR TITLE
feat(components): adding tag component

### DIFF
--- a/.changeset/dull-radios-smoke.md
+++ b/.changeset/dull-radios-smoke.md
@@ -1,0 +1,9 @@
+---
+'@manifest-ui/tag': minor
+'@manifest-ui/hooks': patch
+'@manifest-ui/icons': patch
+'@manifest-ui/styled-system': patch
+'@manifest-ui/themes': patch
+---
+
+Adding tag package

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -3,5 +3,7 @@ export * from './useControlled';
 export * from './useId';
 export * from './useIsomorphicLayoutEffect';
 export * from './useMergedCallbacks';
+export * from './useMergedRef';
 export * from './usePagination';
 export * from './useUncontrolled';
+export * from './useUpdatedRef';

--- a/packages/hooks/src/useMergedRef.ts
+++ b/packages/hooks/src/useMergedRef.ts
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+export function setRef<T>(
+  ref: React.MutableRefObject<T | null> | ((instance: T | null) => void) | null | undefined,
+  value: T | null,
+): void {
+  if (typeof ref === 'function') {
+    ref(value);
+  } else if (ref) {
+    ref.current = value;
+  }
+}
+
+export function useMergedRef<T>(...refs: React.Ref<T>[]) {
+  return React.useCallback((node: T | null) => {
+    refs.forEach(ref => setRef(ref, node));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, refs);
+}

--- a/packages/hooks/src/useUpdatedRef.ts
+++ b/packages/hooks/src/useUpdatedRef.ts
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
+
+/**
+ * Keep the ref during render cycles, but update it if the value changes
+ *
+ * @param value the value or function to keep
+ */
+export function useUpdatedRef<T>(value: T): React.RefObject<T> {
+  const ref = React.useRef(value);
+
+  useIsomorphicLayoutEffect(() => {
+    ref.current = value;
+  });
+
+  return ref;
+}

--- a/packages/hooks/test/useMergedRef.spec.tsx
+++ b/packages/hooks/test/useMergedRef.spec.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { render } from '../../../test/utils';
+import { useMergedRef } from '../src';
+
+function TestComponent({
+  testRef: forwardedRef,
+}: {
+  testRef: React.ForwardedRef<HTMLButtonElement>;
+}) {
+  const ref = React.useRef<HTMLButtonElement>();
+
+  return <button ref={useMergedRef(ref, forwardedRef)} type="button" />;
+}
+
+describe('@manifest-ui/hooks - useMergedRef', () => {
+  it('should be defined', () => {
+    expect(useMergedRef).toBeDefined();
+  });
+
+  it('should merge refs', () => {
+    const testRef = React.createRef<HTMLButtonElement>();
+
+    render(<TestComponent testRef={testRef} />);
+
+    expect(testRef.current instanceof HTMLButtonElement).toBe(true);
+  });
+});

--- a/packages/icons/src/Clear.tsx
+++ b/packages/icons/src/Clear.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { createIcon } from '@manifest-ui/icon';
+
+export const Clear = createIcon(
+  <>
+    <path d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41Z" />
+  </>,
+  'Clear',
+);

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -1,5 +1,6 @@
 export * from './Add';
 export * from './Check';
+export * from './Clear';
 export * from './ExpandMore';
 export * from './KeyboardArrowLeft';
 export * from './KeyboardArrowRight';

--- a/packages/styled-system/src/props/background.ts
+++ b/packages/styled-system/src/props/background.ts
@@ -34,6 +34,7 @@ const config: Configs = {
     property: 'backgroundImage',
     scale: 'colors',
   },
+  backgroundClip: true,
   backgroundSize: true,
   backgroundPosition: true,
   backgroundRepeat: true,

--- a/packages/styled-system/src/props/border.ts
+++ b/packages/styled-system/src/props/border.ts
@@ -88,7 +88,7 @@ const config: Configs = {
   },
   borderTopRadius: {
     properties: ['borderTopLeftRadius', 'borderTopRightRadius'],
-    scale: 'borders',
+    scale: 'radii',
   },
   borderBottomLeftRadius: {
     property: 'borderBottomLeftRadius',
@@ -100,15 +100,15 @@ const config: Configs = {
   },
   borderBottomRadius: {
     properties: ['borderBottomLeftRadius', 'borderBottomRightRadius'],
-    scale: 'borders',
+    scale: 'radii',
   },
   borderLeftRadius: {
     properties: ['borderBottomLeftRadius', 'borderTopLeftRadius'],
-    scale: 'borders',
+    scale: 'radii',
   },
   borderRightRadius: {
     properties: ['borderBottomRightRadius', 'borderTopRightRadius'],
-    scale: 'borders',
+    scale: 'radii',
   },
   borderInlineEndRadius: {
     properties: ['borderTopRightRadius', 'borderBottomRightRadius'],

--- a/packages/styled-system/src/props/other.ts
+++ b/packages/styled-system/src/props/other.ts
@@ -3,6 +3,7 @@ import { Configs, Length, ResponsiveValue } from '../types';
 import { system } from '../core';
 
 export interface OtherProps {
+  animation?: ResponsiveValue<CSS.Property.Animation<Length>>;
   appearance?: ResponsiveValue<CSS.Property.Appearance>;
   visibility?: ResponsiveValue<CSS.Property.Visibility>;
   userSelect?: ResponsiveValue<CSS.Property.UserSelect>;

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@manifest-ui/tag",
+  "version": "0.0.0",
+  "main": "./lib/index.js",
+  "module": "./esm/index.js",
+  "types": "./dts/index.d.ts",
+  "files": [
+    "dts/**/*.d.ts",
+    "esm/**/*.{js,map}",
+    "lib/**/*.{js,map}",
+    "src/**/*.{ts,tsx,json}"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:project-44/manifest-ui.git",
+    "directory": "packages/tag"
+  },
+  "peerDependencies": {
+    "react": "^16.8 || ^17.0"
+  },
+  "dependencies": {
+    "@manifest-ui/hooks": "^0.0.2",
+    "@manifest-ui/icons": "^0.0.12",
+    "@manifest-ui/styled": "^0.0.7"
+  }
+}

--- a/packages/tag/src/Tag.styles.ts
+++ b/packages/tag/src/Tag.styles.ts
@@ -1,0 +1,180 @@
+import { Clear } from '@manifest-ui/icons';
+import { styled } from '@manifest-ui/styled';
+
+export interface StyledTagOptions {
+  /**
+   * The size of the tag.
+   *
+   * @default 'medium'
+   */
+  size?: 'large' | 'medium' | 'small';
+  /**
+   * The tag variant.
+   *
+   * @default 'outlined'
+   */
+  variant?: 'filled' | 'outlined';
+}
+
+const themeKey = 'tag';
+
+export const StyledTag = styled('div', {
+  themeKey,
+})<StyledTagOptions>(
+  {
+    alignItems: 'center',
+    backgroundColor: 'transparent',
+    border: 'solid',
+    borderColor: 'transparent',
+    borderRadius: 'full',
+    borderWidth: 'small',
+    boxSizing: 'border-box',
+    color: 'emphasis.primary',
+    cursor: 'default',
+    display: 'inline-flex',
+    fontFamily: 'body',
+    fontWeight: 'normal',
+    justifyContent: 'center',
+    letterSpacing: 'normal',
+    outline: 0,
+    p: 0,
+    textDecoration: 'none',
+    transitionDuration: 'base',
+    transitionProperty: 'colors',
+    verticalAlign: 'middle',
+    whiteSpace: 'nowrap',
+
+    '& > .manifestui-tag-icon': {
+      '& ~.manifestui-tag-text': {
+        pl: 1,
+      },
+    },
+
+    '&[data-disabled]': {
+      opacity: 0.32,
+      pointerEvents: 'none',
+    },
+
+    '&[data-dismissible]': {
+      '& > .manifestui-tag-text': {
+        pr: 1,
+      },
+    },
+
+    '&[data-clickable]': {
+      cursor: 'pointer',
+      userSelect: 'none',
+    },
+  },
+  ({ variant }) => ({
+    ...(variant === 'outlined' && {
+      borderColor: 'neutral.200',
+
+      '&[data-clickable]': {
+        '&[data-active]': {
+          backgroundColor: 'neutral.200',
+          borderColor: 'neutral.400',
+        },
+
+        '&:hover': {
+          backgroundColor: 'neutral.50',
+          borderColor: 'neutral.400',
+        },
+
+        '&:focus': {
+          backgroundColor: 'neutral.100',
+          borderColor: 'neutral.400',
+        },
+      },
+    }),
+
+    ...(variant === 'filled' && {
+      backgroundColor: 'neutral.100',
+
+      '&[data-clickable]': {
+        '&[data-active]': {
+          backgroundColor: 'neutral.400',
+        },
+
+        '&:hover': {
+          backgroundColor: 'neutral.200',
+        },
+
+        '&:focus': {
+          backgroundColor: 'neutral.300',
+        },
+      },
+    }),
+  }),
+  ({ size }) => ({
+    ...(size === 'large' && {
+      h: 28,
+
+      '& > .manifestui-tag-icon': {
+        ml: 2,
+      },
+
+      '& > .manifestui-tag-text': {
+        fontSize: 'small',
+        lineHeight: 'medium',
+      },
+
+      '& > .manifestui-tag-dismiss, & > .manifestui-tag-icon': {
+        boxSize: '18px',
+      },
+    }),
+
+    ...(size === 'medium' && {
+      h: 24,
+
+      '& > .manifestui-tag-icon': {
+        ml: 2,
+      },
+
+      '& > .manifestui-tag-text': {
+        fontSize: 'x-small',
+        lineHeight: 'small',
+      },
+
+      '& > .manifestui-tag-dismiss, & > .manifestui-tag-icon': {
+        boxSize: '18px',
+      },
+    }),
+
+    ...(size === 'small' && {
+      h: 20,
+
+      '& > .manifestui-tag-icon': {
+        ml: 1,
+      },
+
+      '& > .manifestui-tag-text': {
+        fontSize: 'x-small',
+        lineHeight: 'small',
+      },
+
+      '& > .manifestui-tag-dismiss, & > .manifestui-tag-icon': {
+        boxSize: '16px',
+      },
+    }),
+  }),
+);
+
+export const StyledDismissIcon = styled(Clear, {
+  slot: 'dismiss',
+  themeKey,
+})({
+  cursor: 'pointer',
+  mr: '6px',
+});
+
+export const StyledTagText = styled('span', {
+  slot: 'text',
+  themeKey,
+})({
+  color: 'inherit',
+  fontFamily: 'body',
+  fontWeight: 'normal',
+  letterSpacing: 'normal',
+  px: 3,
+});

--- a/packages/tag/src/Tag.tsx
+++ b/packages/tag/src/Tag.tsx
@@ -1,0 +1,142 @@
+import * as React from 'react';
+import { StyledDismissIcon, StyledTag, StyledTagText } from './Tag.styles';
+import { ComponentProps } from '@manifest-ui/styled';
+import { IconProps } from '@manifest-ui/icon';
+import { useMergedRef } from '@manifest-ui/hooks';
+
+export interface TagOptions {
+  /**
+   * Props for the dismiss icon.
+   */
+  dismissIconProps?: IconProps;
+  /**
+   * The icon rendered at the start of the tag.
+   */
+  icon?: React.ReactNode;
+  /**
+   * Whether the tag is active
+   */
+  isActive?: boolean;
+  /**
+   * Whether the tag is disabled.
+   *
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
+   * Whether the tag is clickable.
+   *
+   * @default false
+   */
+  isClickable?: boolean;
+  /**
+   * Whether the tag is dismissible.
+   *
+   * @default false
+   */
+  isDismissible?: boolean;
+  /**
+   * Callback function fired when the dismiss icon is clicked.
+   */
+  onDismiss?: React.EventHandler<any>;
+}
+
+export interface TagProps extends ComponentProps<typeof StyledTag>, TagOptions {}
+
+export const Tag = React.forwardRef<HTMLDivElement, TagProps>((props: TagProps, ref) => {
+  const {
+    children,
+    dismissIconProps = {},
+    icon: iconProp,
+    isActive,
+    isDisabled,
+    isClickable,
+    isDismissible,
+    onClick,
+    onDismiss,
+    onKeyUp,
+    onKeyDown,
+    size = 'large',
+    variant = 'outlined',
+    ...other
+  } = props;
+
+  const tagRef = React.useRef<HTMLDivElement>(null);
+  const mergedRef = useMergedRef(tagRef, ref);
+
+  const handleDismiss = React.useCallback(
+    (event: React.MouseEvent<SVGSVGElement>) => {
+      event.stopPropagation();
+
+      onDismiss?.(event);
+    },
+    [onDismiss],
+  );
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (
+        event.currentTarget === event.target &&
+        (event.key === 'Backspace' || event.key === 'Delete')
+      ) {
+        event.preventDefault();
+      }
+
+      onKeyDown?.(event);
+    },
+    [onKeyDown],
+  );
+
+  const handleKeyUp = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.currentTarget === event.target) {
+        if (onDismiss && (event.key === 'Backspace' || event.key === 'Delete')) {
+          onDismiss(event);
+        } else if (event.key === 'Escape' && tagRef.current) {
+          tagRef.current.blur();
+        }
+      }
+
+      onKeyUp?.(event);
+    },
+    [onDismiss, onKeyUp],
+  );
+
+  let icon = null;
+  if (iconProp && React.isValidElement(iconProp)) {
+    icon = React.cloneElement(iconProp, {
+      className: 'manifestui-tag-icon',
+    });
+  }
+
+  return (
+    <StyledTag
+      as={isClickable || onDismiss ? 'button' : 'div'}
+      className="manifestui-tag"
+      data-active={isActive ? '' : null}
+      data-clickable={isClickable ? '' : null}
+      data-disabled={isDisabled ? '' : null}
+      data-dismissible={isDismissible ? '' : null}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+      onKeyUp={handleKeyUp}
+      ref={mergedRef}
+      size={size}
+      variant={variant}
+      {...(isClickable && { role: 'button', tabIndex: isDisabled ? -1 : 0 })}
+      {...other}
+    >
+      {icon}
+      <StyledTagText className="manifestui-tag-text">{children}</StyledTagText>
+      {isDismissible && (
+        <StyledDismissIcon
+          className="manifestui-tag-dismiss"
+          onClick={handleDismiss}
+          {...dismissIconProps}
+        />
+      )}
+    </StyledTag>
+  );
+});
+
+Tag.displayName = 'Tag';

--- a/packages/tag/src/index.ts
+++ b/packages/tag/src/index.ts
@@ -1,0 +1,1 @@
+export * from './Tag';

--- a/packages/tag/stories/Tag.stories.tsx
+++ b/packages/tag/stories/Tag.stories.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { Tag, TagProps } from '../src';
+
+export default {
+  title: 'Components/Tag',
+  component: Tag,
+  argTypes: {
+    children: { control: 'text' },
+  },
+};
+
+export const Default = (args: TagProps) => <Tag {...args} />;
+Default.args = {
+  children: 'Default',
+};

--- a/packages/tag/test/Tag.spec.tsx
+++ b/packages/tag/test/Tag.spec.tsx
@@ -1,0 +1,130 @@
+import * as React from 'react';
+import { act, fireEvent, render, screen, testA11y, userEvent } from '../../../test/utils';
+import { Tag } from '../src';
+
+describe('@manifest-ui/tag', () => {
+  it('should pass accessibility', async () => {
+    await testA11y(<Tag>Custom Tag</Tag>);
+  });
+
+  it('should pass accessibility when interactive', async () => {
+    const dismissSpy = jest.fn();
+
+    await testA11y(<Tag onDismiss={dismissSpy}>Custom Tag</Tag>);
+  });
+
+  it('should render with just text', () => {
+    render(<Tag>Custom Tag</Tag>);
+
+    expect(screen.getByText('Custom Tag')).toBeDefined();
+  });
+
+  it('should render with dismiss button', () => {
+    const dismissSpy = jest.fn();
+    const onKeyDownSpy = jest.fn();
+    const onKeyUpSpy = jest.fn();
+
+    render(
+      <Tag
+        dismissIconProps={{ 'aria-label': 'delete' }}
+        isDismissible
+        onDismiss={dismissSpy}
+        onKeyDown={onKeyDownSpy}
+        onKeyUp={onKeyUpSpy}
+      >
+        Custom Tag
+      </Tag>,
+    );
+
+    const tag = screen.getByRole('button');
+
+    act(() => {
+      tag.focus();
+    });
+
+    expect(screen.getByRole('button')).toHaveProperty('tabIndex', 0);
+
+    fireEvent.click(screen.getByLabelText('delete'));
+
+    expect(dismissSpy).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(tag, { key: 'Delete' });
+
+    expect(dismissSpy).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyUp(tag, { key: 'Delete' });
+
+    expect(dismissSpy).toHaveBeenCalledTimes(2);
+
+    fireEvent.keyDown(tag, { key: 'Backspace' });
+
+    expect(dismissSpy).toHaveBeenCalledTimes(2);
+
+    fireEvent.keyUp(tag, { key: 'Backspace' });
+
+    expect(dismissSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('should handle click events', () => {
+    const onClickSpy = jest.fn();
+    const onKeyDownSpy = jest.fn();
+    const onKeyUpSpy = jest.fn();
+
+    render(
+      <Tag isClickable onClick={onClickSpy} onKeyDown={onKeyDownSpy} onKeyUp={onKeyUpSpy}>
+        Custom Tag
+      </Tag>,
+    );
+
+    const tag = screen.getByRole('button');
+
+    expect(tag).toHaveProperty('tabIndex', 0);
+
+    act(() => {
+      tag.focus();
+    });
+
+    userEvent.keyboard('{x}');
+
+    expect(onKeyDownSpy).toHaveBeenCalledTimes(1);
+    expect(onKeyUpSpy).toHaveBeenCalledTimes(1);
+
+    userEvent.keyboard('{escape}');
+
+    expect(tag).not.toHaveFocus();
+
+    act(() => {
+      tag.focus();
+    });
+
+    expect(tag).toHaveFocus();
+
+    userEvent.keyboard('{space}');
+
+    expect(onClickSpy).toHaveBeenCalledTimes(1);
+
+    userEvent.keyboard('{enter}');
+
+    expect(onClickSpy).toHaveBeenCalledTimes(2);
+
+    userEvent.click(tag);
+
+    expect(onClickSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('should support is disabled', () => {
+    const onClickSpy = jest.fn();
+    const dismissSpy = jest.fn();
+
+    render(
+      <Tag isDisabled onClick={onClickSpy} onDismiss={dismissSpy}>
+        Custom Tag
+      </Tag>,
+    );
+
+    const tag = screen.getByText('Custom Tag').parentElement;
+
+    expect(tag).toBeDefined();
+    expect(tag).toHaveAttribute('data-disabled');
+  });
+});

--- a/packages/tag/tsconfig.json
+++ b/packages/tag/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "declarationDir": "dts",
+    "outDir": "dts",
+    "rootDir": "src",
+    "emitDeclarationOnly": true
+  },
+  "exclude": ["dts", "tests"],
+  "extends": "../../tsconfig.options.json",
+  "include": ["src/**/*", "types/**/*", "../../types/**/*"],
+  "references": [
+    {
+      "path": "../hooks"
+    },
+    {
+      "path": "../icons"
+    },
+    {
+      "path": "../styled"
+    }
+  ]
+}

--- a/packages/themes/src/default.ts
+++ b/packages/themes/src/default.ts
@@ -268,7 +268,7 @@ export const defaultTheme = {
     medium: '1rem',
     small: '0.875rem',
     'x-small': '0.75rem',
-    'xx-small': '0.625',
+    'xx-small': '0.625rem',
   },
   fontWeights: {
     extrathin: 100,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -63,6 +63,9 @@
       "path": "packages/table"
     },
     {
+      "path": "packages/tag"
+    },
+    {
       "path": "packages/theme"
     },
     {


### PR DESCRIPTION
# Description

DES-32 | Adding tag package

Add the base implementation of the tag component. Supports icons, dismissing, clicking. 

Outlined variant
<img width="1045" alt="Screen Shot 2022-02-15 at 5 18 24 PM" src="https://user-images.githubusercontent.com/98107867/154166917-f35b3805-c49e-4da2-a91a-8ecfc2a3811e.png">

Filled variant
<img width="1045" alt="Screen Shot 2022-02-15 at 5 18 32 PM" src="https://user-images.githubusercontent.com/98107867/154166927-d536b028-3255-4dd4-a68f-2b278bfe4a18.png">

# 🔍  How to test this change locally

1. Run `yarn && yarn build && yarn dev`
1. Confirm changes by reviewing the tag story.

# 🔮  Outstanding Questions

* Focus state does not match the other clickable elements. We should probably align here.