### PR TITLE
fix(themes): fix themes version

### DIFF
--- a/.changeset/real-boats-eat.md
+++ b/.changeset/real-boats-eat.md
@@ -1,0 +1,7 @@
+---
+'@manifest-ui/styled': patch
+'@manifest-ui/theme': patch
+'@manifest-ui/themes': patch
+---
+
+Fixing themes package version

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@manifest-ui/styled-system": "^0.0.7",
-    "@manifest-ui/themes": "^0.1.2",
+    "@manifest-ui/themes": "^0.2.2",
     "lodash.isempty": "^4.4.0",
     "lodash.omitby": "^4.6.0"
   }

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -20,7 +20,7 @@
     "react": "^16.8 || ^17.0"
   },
   "dependencies": {
-    "@manifest-ui/themes": "^0.1.0",
+    "@manifest-ui/themes": "^0.2.2",
     "deepmerge": "^4.2.2"
   }
 }

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifest-ui/themes",
-  "version": "0.1.2",
+  "version": "0.2.2",
   "main": "./lib/index.js",
   "types": "./dts/index.d.ts",
   "files": [


### PR DESCRIPTION
# Description

The themes package version was too low, an older release of `@manifest-ui/themes` was being used instead of the newest package. Bumping this package version to the highest known version.