### PR TITLE
fix(Pagination): Update spacing to design spec

### DIFF
--- a/.changeset/honest-ravens-sip.md
+++ b/.changeset/honest-ravens-sip.md
@@ -1,0 +1,5 @@
+---
+'@manifest-ui/pagination': patch
+---
+
+Update spacing to match design spec

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -16,6 +16,7 @@ export const parameters = {
   actions: { argTypesRegex: '^on.*' },
   options: {
     storySort: {
+      method: 'alphabetical',
       order: ['Welcome', 'Components'],
     },
   },

--- a/packages/pagination/src/Pagination.styles.ts
+++ b/packages/pagination/src/Pagination.styles.ts
@@ -7,7 +7,7 @@ export const StyledPagination = styled('div', {
 })({
   alignItems: 'center',
   boxSizing: 'border-box',
-  columnGap: '8px',
+  columnGap: '4px',
   display: 'flex',
   flexWrap: 'wrap',
   justifyContent: 'flex-start',


### PR DESCRIPTION
# Description

Adhere to the spacing defined in the 4pt grid system. Is currently set to `8px` Update component to match design accordingly.

# 🏠 After

<img width="1440" alt="Screen Shot 2022-02-17 at 3 06 57 PM" src="https://user-images.githubusercontent.com/88858003/154571596-ebf55e3c-db17-4483-8efc-6454031089c7.png">

