### PR TITLE
feat(select): add optional start icon

### DIFF
--- a/.changeset/tall-planes-joke.md
+++ b/.changeset/tall-planes-joke.md
@@ -1,0 +1,5 @@
+---
+'@manifest-ui/select': minor
+---
+
+add optional start icon

--- a/packages/select/src/Select.styles.ts
+++ b/packages/select/src/Select.styles.ts
@@ -56,6 +56,10 @@ export const StyledControl = styled('div', {
     borderColor: 'status.danger.500',
     color: 'status.danger.500',
   },
+
+  '&[data-startIcon]': {
+    pl: 0,
+  },
 });
 
 export const StyledIndicatorContainer = styled('div', {

--- a/packages/select/src/Select.styles.ts
+++ b/packages/select/src/Select.styles.ts
@@ -103,6 +103,19 @@ export const StyledInput = styled('input', {
   width: '100%',
 });
 
+export const StyledInputIcon = styled('div', {
+  slot: 'icon',
+  themeKey,
+})({
+  alignItems: 'center',
+  color: 'emphasis.tertiary',
+  display: 'flex',
+  justifyContent: 'center',
+  pe: 2,
+  ps: 2,
+  pointerEvents: 'none',
+});
+
 export const StyledMenu = styled('div', {
   shouldForwardProp: (prop: string) => shouldForwardProp(prop) && !props.has(prop),
   slot: 'menu',
@@ -221,7 +234,9 @@ export const StyledPlaceholder = styled('div', {
   slot: 'placeholder',
   themeKey,
 })({
+  alignItems: 'center',
   color: 'emphasis.tertiary',
+  display: 'flex',
   opacity: 1,
   padding: 0,
   position: 'absolute',

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -104,17 +104,22 @@ const components: ReactSelectProps['components'] = {
       <Clear className="manifestui-select__clear-icon" />
     </StyledIndicatorContainer>
   ),
-  Control: ({ innerProps, innerRef, children, isDisabled, isFocused }) => (
-    <StyledControl
-      className="manifestui-select__control"
-      data-disabled={isDisabled ? '' : null}
-      data-focus={isFocused ? '' : null}
-      ref={innerRef}
-      {...innerProps}
-    >
-      {children}
-    </StyledControl>
-  ),
+  Control: ({ innerProps, innerRef, children, isDisabled, isFocused, selectProps }) => {
+    const { startIcon } = selectProps;
+
+    return (
+      <StyledControl
+        className="manifestui-select__control"
+        data-disabled={isDisabled ? '' : null}
+        data-focus={isFocused ? '' : null}
+        ref={innerRef}
+        data-startIcon={startIcon}
+        {...innerProps}
+      >
+        {children}
+      </StyledControl>
+    );
+  },
   DropdownIndicator: ({ innerProps, isDisabled }) => (
     <StyledIndicatorContainer
       className="manifestui-select__indicator-container"

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -7,6 +7,7 @@ import {
   StyledIndicatorContainer,
   StyledIndicatorsContainer,
   StyledInput,
+  StyledInputIcon,
   StyledMenu,
   StyledMultiValue,
   StyledMultiValueLabel,
@@ -67,6 +68,10 @@ export interface SelectProps {
    * Placeholder for the select value
    */
   placeholder?: React.ReactNode;
+  /**
+   * Icon to display at the start of the select
+   */
+  startIcon?: React.ReactNode;
   /**
    * The value of the select; reflected by the selected option
    */
@@ -164,9 +169,17 @@ const components: ReactSelectProps['components'] = {
       {children}
     </StyledOption>
   ),
-  Placeholder: ({ children }) => {
+  Placeholder: ({ children, selectProps }) => {
+    const { startIcon } = selectProps;
     return (
-      <StyledPlaceholder className="manifestui-select__placeholder">{children}</StyledPlaceholder>
+      <StyledPlaceholder className="manifestui-select__placeholder">
+        {startIcon && (
+          <StyledInputIcon className="manifestui-input-startIcon" data-placement="start">
+            {startIcon}
+          </StyledInputIcon>
+        )}
+        {children}
+      </StyledPlaceholder>
     );
   },
   SingleValue: ({ innerProps, children }) => (
@@ -174,13 +187,23 @@ const components: ReactSelectProps['components'] = {
       {children}
     </StyledSingleValue>
   ),
-  ValueContainer: ({ isDisabled, theme, ...other }) => (
-    <StyledValueContainer className="manifestui-select__value-container" {...other} />
-  ),
+  ValueContainer: ({ children, isDisabled, selectProps, theme, ...other }) => {
+    const { startIcon } = selectProps;
+    return (
+      <StyledValueContainer className="manifestui-select__value-container" {...other}>
+        {startIcon && (
+          <StyledInputIcon className="manifestui-input-startIcon" data-placement="start">
+            {startIcon}
+          </StyledInputIcon>
+        )}
+        {children}
+      </StyledValueContainer>
+    );
+  },
 };
 
 export const Select = React.forwardRef<HTMLDivElement, SelectProps>((props: SelectProps, ref) => {
-  const { id, placeholder, isSearchable = false, ...other } = props;
+  const { id, placeholder, isSearchable = false, startIcon, ...other } = props;
 
   return (
     <StyledSelect className="manifestui-select" ref={ref}>
@@ -190,6 +213,7 @@ export const Select = React.forwardRef<HTMLDivElement, SelectProps>((props: Sele
         inputId={id}
         isSearchable={isSearchable}
         placeholder={placeholder ?? ''}
+        startIcon={startIcon}
         {...other}
       />
     </StyledSelect>

--- a/packages/select/stories/Select.stories.tsx
+++ b/packages/select/stories/Select.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Select, SelectProps } from '../src';
 import { Meta } from '@storybook/react';
+import { Person } from '@manifest-ui/icons';
 
 export default {
   title: 'Components/Select',
@@ -19,4 +20,19 @@ Default.args = {
     { label: 'Stop Name', value: 'stop' },
   ],
   placeholder: 'Base',
+};
+
+export const WithStartIcon = Default.bind({});
+
+WithStartIcon.args = {
+  options: [
+    { label: 'Running Late', value: 'late' },
+    { label: 'Running Early', value: 'early' },
+    { label: 'Estimated Time', value: 'estimated' },
+    { label: 'Planned Time', value: 'planned' },
+    { label: 'Actual Time', value: 'actual' },
+    { label: 'Stop Name', value: 'stop' },
+  ],
+  placeholder: 'Base',
+  startIcon: <Person />,
 };

--- a/packages/select/test/Select.spec.tsx
+++ b/packages/select/test/Select.spec.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Person } from '@manifest-ui/icons';
 import { render } from '../../../test/utils';
 import { Select } from '../src';
 
@@ -22,5 +23,24 @@ describe('@manifest-ui/select', () => {
         placeholder="Basic Select"
       />,
     );
+  });
+
+  it('should render with a startIcon if prop is specified', () => {
+    render(
+      <Select
+        options={[
+          { label: 'Running Late', value: 'late' },
+          { label: 'Running Early', value: 'early' },
+          { label: 'Estimated Time', value: 'estimated' },
+          { label: 'Planned Time', value: 'planned' },
+          { label: 'Actual Time', value: 'actual' },
+          { label: 'Stop Name', value: 'stop' },
+        ]}
+        placeholder="Basic Select"
+        startIcon={<Person />}
+      />,
+    );
+
+    expect(document.querySelector('.manifestui-input-startIcon')).toBeTruthy();
   });
 });

--- a/packages/select/types/react-select.d.ts
+++ b/packages/select/types/react-select.d.ts
@@ -1,0 +1,11 @@
+import { GroupBase } from 'react-select';
+
+declare module 'react-select/dist/declarations/src/Select' {
+  export interface Props<
+    Option,
+    IsMulti extends boolean,
+    Group extends GroupBase<Option>
+  > {
+    startIcon?: React.ReactNode;
+  }
+}


### PR DESCRIPTION
Implement optional startIcon prop for Select component
<img width="609" alt="Screen Shot 2022-04-15 at 5 27 20 PM" src="https://user-images.githubusercontent.com/14588617/163649356-e0f7022b-8164-4a68-b593-532f7b27ebe5.png">

<img width="609" alt="Screen Shot 2022-04-15 at 5 27 37 PM" src="https://user-images.githubusercontent.com/14588617/163649377-b1c196ba-0c3b-468a-9112-e381e7978a07.png">


Closes #205 
