### PR TITLE
fix(pagination): fixing line height on ellipsis

### DIFF
--- a/.changeset/serious-rats-learn.md
+++ b/.changeset/serious-rats-learn.md
@@ -1,0 +1,5 @@
+---
+'@manifest-ui/pagination': patch
+---
+
+Fixing line height on pagination ellipsis

--- a/packages/pagination/src/Pagination.styles.ts
+++ b/packages/pagination/src/Pagination.styles.ts
@@ -78,9 +78,8 @@ export const StyledPaginationEllipsis = styled('div', {
   fontWeight: 'semibold',
   height: 'auto',
   letterSpacing: 'normal',
-  lineHeight: 'large',
-  px: 3,
-  py: 2,
+  lineHeight: 'medium',
+  p: 2,
   textAlign: 'center',
 });
 

--- a/packages/pagination/src/Pagination.tsx
+++ b/packages/pagination/src/Pagination.tsx
@@ -11,7 +11,14 @@ import { ComponentProps } from '@manifest-ui/styled';
 
 export interface PaginationProps
   extends Omit<ComponentProps<typeof StyledPagination>, 'onChange'>,
-    UsePaginationOptions {}
+    UsePaginationOptions {
+  /**
+   * Whether to show page numbers buttons.
+   *
+   * @default true
+   */
+  showPageNumbers?: boolean;
+}
 
 export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
   (props: PaginationProps, ref) => {
@@ -22,6 +29,7 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
       page: pageProp,
       rowsPerPage,
       siblings,
+      showPageNumbers = true,
       totalRowCount,
       ...other
     } = props;
@@ -50,28 +58,29 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
           </StyledPaginationText>
         </StyledPaginationButton>
 
-        {pages.map((item, index) => (
-          <React.Fragment key={`${item}_${index}`}>
-            {item === 'dots' && (
-              <StyledPaginationEllipsis className="manifestui-pagination-ellipsis">
-                ...
-              </StyledPaginationEllipsis>
-            )}
-            {item !== 'dots' && (
-              <StyledPaginationButton
-                aria-current={item === page ? 'true' : undefined}
-                aria-label={`${item === page ? '' : 'go to '}page ${String(item)}`}
-                className="manifestui-pagination-button"
-                data-active={item === page ? '' : undefined}
-                onClick={() => {
-                  setPage(item as number);
-                }}
-              >
-                {item.toString()}
-              </StyledPaginationButton>
-            )}
-          </React.Fragment>
-        ))}
+        {showPageNumbers &&
+          pages.map((item, index) => (
+            <React.Fragment key={`${item}_${index}`}>
+              {item === 'dots' && (
+                <StyledPaginationEllipsis className="manifestui-pagination-ellipsis">
+                  ...
+                </StyledPaginationEllipsis>
+              )}
+              {item !== 'dots' && (
+                <StyledPaginationButton
+                  aria-current={item === page ? 'true' : undefined}
+                  aria-label={`${item === page ? '' : 'go to '}page ${String(item)}`}
+                  className="manifestui-pagination-button"
+                  data-active={item === page ? '' : undefined}
+                  onClick={() => {
+                    setPage(item as number);
+                  }}
+                >
+                  {item.toString()}
+                </StyledPaginationButton>
+              )}
+            </React.Fragment>
+          ))}
 
         <StyledPaginationButton
           aria-label="go to next page"

--- a/packages/pagination/test/Pagination.spec.tsx
+++ b/packages/pagination/test/Pagination.spec.tsx
@@ -32,6 +32,12 @@ describe('@manifest-ui/pagination', () => {
     expect(screen.getAllByRole('button')[1]).toHaveAttribute('aria-current', 'true');
   });
 
+  it('should render without page numbers', () => {
+    render(<Pagination totalRowCount={100} showPageNumbers={false} />);
+
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+  });
+
   it.each(['filled', 'outlined', 'text'])('should render %s variant', variant => {
     render(<Pagination totalRowCount={100} variant={variant as PaginationProps['variant']} />);
   });


### PR DESCRIPTION
Lowering line height on pagination ellipsis as well as making it possible to hide the page numbers on the pagination component.