### PR TITLE
fix: forward variant and size props

### DIFF
--- a/.changeset/sixty-moose-greet.md
+++ b/.changeset/sixty-moose-greet.md
@@ -1,0 +1,5 @@
+---
+'@manifest-ui/styled': patch
+---
+
+Forward variant and size props on styled components

--- a/packages/styled/src/shouldForwardProp.ts
+++ b/packages/styled/src/shouldForwardProp.ts
@@ -1,5 +1,5 @@
 import { systemProps } from './isStyleProp';
 
-const props = new Set([...systemProps, 'as', 'size', 'sx', 'theme', 'variant']);
+const props = new Set([...systemProps, 'as', 'sx', 'theme']);
 
 export const shouldForwardProp = (prop: string): boolean => !props.has(prop);

--- a/packages/styled/test/styled.spec.tsx
+++ b/packages/styled/test/styled.spec.tsx
@@ -166,4 +166,20 @@ describe('@manifest-ui/styled - styled', () => {
     expect(screen.getByText('Hello')).toHaveStyle('border: 1px solid black');
     expect(screen.getByText('Hello')).toHaveStyle('width: 200px');
   });
+
+  it('should support styling styled compponents', () => {
+    const Button = styled('button')(({ variant }) => ({
+      ...(variant === 'test' && {
+        height: 200,
+      }),
+    }));
+
+    const StyledButton = styled(Button)({
+      color: 'pink',
+    });
+
+    render(<StyledButton variant="test">Hello</StyledButton>);
+
+    expect(screen.getByText('Hello')).toHaveStyle('color: pink; height: 200px');
+  });
 });


### PR DESCRIPTION
Size and variants props need to be forwarded to styled components to ensure that styles resolve correctly.